### PR TITLE
Fix accidental renaming of INPUT_FILE

### DIFF
--- a/test/crab3/crab3_B2GTTreeNtuples.csh
+++ b/test/crab3/crab3_B2GTTreeNtuples.csh
@@ -82,7 +82,7 @@ if ( `echo $cmd | grep "create" | wc -l` ) then
     if ( $#argv < 6 ) then
 	cat Usage.txt; rm Usage.txt; exit
     endif
-    set INSStatusPUT_FILE=$3
+    set INPUT_FILE=$3
     set XSEC_FILE=$4
     set SE_SITE=$5
     set SE_USERDIR=$6


### PR DESCRIPTION
In crab3_B2GTTreeNtuples.csh, INPUT_FILE had been accidentally renamed when it was being set; as a result, the script refused to run. This commit fixes that.
